### PR TITLE
Fix japanese ime parsing

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -482,7 +482,13 @@ class Editor {
     });
     this.rerender();
     if (currentRange) {
-      this.selectRange(currentRange.move(DIRECTION.FORWARD));
+      let endOfString = currentRange;
+      let editStringLength = this._editHistory._pendingSnapshot.range.tail[1];
+      this.loggerFor('editor').log('Moving cursor forwards ' + editStringLength + ' times.');
+      for(let i = 0; i < editStringLength; i++){
+        endOfString = endOfString.move(DIRECTION.FORWARD);
+      }
+      this.selectRange(endOfString);
     }
 
     this.runCallbacks(CALLBACK_QUEUES.DID_REPARSE);

--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -9,6 +9,8 @@ import Key from 'mobiledoc-kit/utils/key';
 import TextInputHandler from 'mobiledoc-kit/editor/text-input-handler';
 import SelectionManager from 'mobiledoc-kit/editor/selection-manager';
 import Browser from 'mobiledoc-kit/utils/browser';
+import { removeClassName } from '../utils/dom-utils';
+import { EDITOR_HAS_NO_CONTENT_CLASS_NAME } from '../renderers/editor-dom';
 
 const ELEMENT_EVENT_TYPES = [
   'keydown', 'keyup', 'cut', 'copy', 'paste', 'keypress', 'drop'
@@ -161,6 +163,12 @@ export default class EventManager {
       event.preventDefault();
       if (editor.post.isBlank) {
         editor._insertEmptyMarkupSectionAtCursor();
+      }
+      if(!editor.post.hasContent){
+        if((Key.fromEvent(event)).isPrintable()){
+          let { editor: { element } } = this;
+          removeClassName(element, EDITOR_HAS_NO_CONTENT_CLASS_NAME);
+        }
       }
       return;
     }

--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -36,6 +36,8 @@ export default class EventManager {
     ELEMENT_EVENT_TYPES.forEach(type => {
       this._addListener(element, type);
     });
+    this._addListener(element, 'compositionstart');
+    this._addListener(element, 'compositionend');
 
     this._selectionManager.start();
   }
@@ -281,6 +283,14 @@ export default class EventManager {
       let nextPosition = postEditor.insertPost(position, post);
       postEditor.setRange(nextPosition);
     });
+  }
+
+  compositionstart() {
+      this.editor.compositionstart();
+  }
+
+  compositionend() {
+      this.editor.compositionend();
   }
 
   _updateModifiersFromKey(key, {isDown}) {

--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -157,7 +157,13 @@ export default class EventManager {
     if (!editor.isEditable) { return; }
 
     const isImeEvent = event.keyCode === 229;
-    if (isImeEvent) { return; }
+    if (isImeEvent) { 
+      event.preventDefault();
+      if (editor.post.isBlank) {
+        editor._insertEmptyMarkupSectionAtCursor();
+      }
+      return;
+    }
 
     let key = Key.fromEvent(event);
     this._updateModifiersFromKey(key, {isDown:true});


### PR DESCRIPTION
Fixed:
- First character parsed into markers on initial input
- Duplicate first character on initial input when sections are empty
- Cursor moving 1 unit forward regardless of string length 